### PR TITLE
Remove explosions when we reset the game

### DIFF
--- a/src/Objects/Exploder.js
+++ b/src/Objects/Exploder.js
@@ -11,6 +11,8 @@ export default class Exploder extends Phaser.Physics.Arcade.Sprite {
         this.blastWaveCount = 1;
 
         this.explosionGroup = this.scene.physics.add.group();
+        this.warningGroup = this.scene.physics.add.group();
+        this.tweenCollection = [];
     }
 
     setLocation(x, y) {
@@ -36,7 +38,9 @@ export default class Exploder extends Phaser.Physics.Arcade.Sprite {
         var startingRadius = 0;
 
         var warning = this.scene.add.circle(x, y, radius, 0xF2CD60, 0.45);
-        this.scene.tweens.add({
+        this.warningGroup.add(warning);
+
+        let warningTween = this.scene.tweens.add({
             targets: warning,
             alpha: 0.35,
             step: 1,
@@ -44,13 +48,15 @@ export default class Exploder extends Phaser.Physics.Arcade.Sprite {
             yoyo: true,
             repeat: -1
         });
+        this.tweenCollection.push(warningTween);
 
         var explosion = this.scene.add.circle(x, y, startingRadius, 0xF25757); // Should the starting radius be an argument?
+        this.explosionGroup.add(explosion);
 
         warning.setDepth(-2);
         explosion.setDepth(-1);
 
-        this.scene.tweens.add({
+        let explosionTween = this.scene.tweens.add({
             targets: explosion,
             delay: delay * 1000,
             radius: radius,
@@ -60,8 +66,7 @@ export default class Exploder extends Phaser.Physics.Arcade.Sprite {
                 warning.destroy();
             },
         });
-
-        this.explosionGroup.add(explosion);
+        this.tweenCollection.push(explosionTween);
     }
 
     createExplosions(count = 1) { // These need to be tweaked along with the explode() function
@@ -72,5 +77,16 @@ export default class Exploder extends Phaser.Physics.Arcade.Sprite {
             var randDuration = Phaser.Math.FloatBetween(0.25, 1);
             this.explode(randX, randY, randRadius, randDuration);
         }
+    }
+
+    // We need to remove all tweens for warnings and explosions first
+    // (so they're not trying to update non-existent objects), then
+    // remove all warnings and explosions.
+    reset() {
+        this.tweenCollection.forEach((t) => { t.remove(); });
+        this.tweenCollection = [];
+        this.explosionGroup.clear(true, true);
+        this.warningGroup.clear(true, true);
+        this.blastWaveCount = 1;
     }
 }

--- a/src/Scenes/GameScene.js
+++ b/src/Scenes/GameScene.js
@@ -16,6 +16,7 @@ var isLooking = true;
 var coolometerCount;
 var coolometerMax;
 var sightcone;
+var warningGroup;
 var explosionGroup;
 var raycaster;
 var ray;
@@ -69,6 +70,7 @@ export default class GameScene extends Phaser.Scene {
 
         this.exploder.startWave();
         explosionGroup = this.exploder.explosionGroup;
+        warningGroup = this.exploder.warningGroup;
 
         keys = this.input.keyboard.addKeys({
             'up': Phaser.Input.Keyboard.KeyCodes.UP,
@@ -127,7 +129,6 @@ export default class GameScene extends Phaser.Scene {
         };
         this.overlayManager = new OverlayManager(this, overlayMap);
     }
-
 
     addSightcone() {
         sightcone = this.add.triangle(
@@ -205,7 +206,7 @@ export default class GameScene extends Phaser.Scene {
         isLooking = canSeeAnyExplosions;
 
         if (!isLooking && (coolometerCount < coolometerMax)){
-            coolometerCount = Math.min(coolometerMax, coolometerCount + 0.3);
+            coolometerCount = Math.min(coolometerMax, coolometerCount + 0.6);
         }
         else if (isLooking && (coolometerCount > 0)){
             coolometerCount = Math.max(0, coolometerCount - 10);
@@ -359,11 +360,6 @@ export default class GameScene extends Phaser.Scene {
         if (this.overlayManager.overlayStack.length == 0) {
             this.pauseGame();
             this.overlayManager.openTarget('pause');
-        } else {
-            this.overlayManager.disableTop();
-            if (this.overlayManager.overlayStack.length == 0) {
-                this.unpauseGame();
-            }
         }
     }
 
@@ -400,7 +396,6 @@ export default class GameScene extends Phaser.Scene {
         this.score.resetScore();
         coolometerCount = 0;
         this.gameStartTime = Date.now();
-
-        // @TODO: add whatever is required to reset explosions
+        this.exploder.reset();
     }
 };


### PR DESCRIPTION
Needed to keep track of the warning circles on the exploder object as well as all the tweens attached to the warnings and explosions.

Also removed the ability to hit esc to exit an overlay as it doesn't work for title => game and gameOver => game transitions